### PR TITLE
Generate a copiable video link and adjust permissions to enable copy

### DIFF
--- a/classes/GUI/Abstract/class.xvmpGUI.php
+++ b/classes/GUI/Abstract/class.xvmpGUI.php
@@ -260,7 +260,7 @@ abstract class xvmpGUI {
             $perm_link->setIncludePermanentLinkText(false);
             $video_infos .= $perm_link->getHTML();
         }
-
+		$video_infos = $video_infos . $this->getLinkHTML($video);
 		$response = new stdClass();
 		if ($video->getStatus() === 'legal' || !xvmpConf::getConfig(xvmpConf::F_EMBED_PLAYER)) {
 			$video_player_html = (new xvmpVideoPlayer($video, xvmp::useEmbeddedPlayer($this->getObjId(), $video)))->getHTML();
@@ -282,7 +282,40 @@ abstract class xvmpGUI {
         }
 	}
 
+	private function getLinkHTML($video)
+	{
+		global $DIC;
+		//xvmpRequest::getAllAsArray();
+		$medium = $video->getMedium();
+		if (is_array($medium)){
+			
+			$medium = $medium[0];
+		}
+		$video_link = $video->getSource();
+		$html = '';
+		if(ilObjViMPAccess::hasAccessToLink()){
+			$html = new ilTemplate("tpl.copylink.html", true, true, $this->pl->getDirectory());
+			$html->setVariable("{INFO_COPYLINK}", $this->pl->txt("perm_readlink"));
+			$html->setVariable("COPYLINK", $medium);
+			$html = $html->get();
 
+			/*
+			//Use template to generate HTML
+			$link_info = '<div class ="link-info"><p>'. $this->pl->txt("perm_readlink"). '</p></div>';
+			$html_ = '<div class="ilInfoScreenSec form-horizontal video-url"><div class="ilPermalinkContainer input-group">'.
+					'<input class="form-control" readonly="readonly" id="videoUrl" type="text"'.
+					'value="' .$medium .'"'.
+					' onclick="return false;">'.
+					'<span class="input-group-btn">	<div class="btn-group"><button type="button" class="btn btn-default" id="copyVideoUrl">'.
+					'<span class="sr-only">Copy to clipboard</span><span class="glyphicon glyphicon-copy"></span></button></div></span></div></div>';
+			
+			$copy_js = "<script> $('#copyVideoUrl',document).on('click',function(e){let copyText=$('#videoUrl',document).get(0);copyText.select();copyText.setSelectionRange(0,99999);document.execCommand('copy')});</script>";
+			$html = $link_info . $html . $copy_js;*/
+
+			return $html;
+		}
+		return '';
+	}
 
 	/**
 	 * ajax

--- a/classes/GUI/Abstract/class.xvmpGUI.php
+++ b/classes/GUI/Abstract/class.xvmpGUI.php
@@ -299,19 +299,6 @@ abstract class xvmpGUI {
 			$html->setVariable("COPYLINK", $medium);
 			$html = $html->get();
 
-			/*
-			//Use template to generate HTML
-			$link_info = '<div class ="link-info"><p>'. $this->pl->txt("perm_readlink"). '</p></div>';
-			$html_ = '<div class="ilInfoScreenSec form-horizontal video-url"><div class="ilPermalinkContainer input-group">'.
-					'<input class="form-control" readonly="readonly" id="videoUrl" type="text"'.
-					'value="' .$medium .'"'.
-					' onclick="return false;">'.
-					'<span class="input-group-btn">	<div class="btn-group"><button type="button" class="btn btn-default" id="copyVideoUrl">'.
-					'<span class="sr-only">Copy to clipboard</span><span class="glyphicon glyphicon-copy"></span></button></div></span></div></div>';
-			
-			$copy_js = "<script> $('#copyVideoUrl',document).on('click',function(e){let copyText=$('#videoUrl',document).get(0);copyText.select();copyText.setSelectionRange(0,99999);document.execCommand('copy')});</script>";
-			$html = $link_info . $html . $copy_js;*/
-
 			return $html;
 		}
 		return '';

--- a/classes/class.ilObjViMPAccess.php
+++ b/classes/class.ilObjViMPAccess.php
@@ -116,6 +116,25 @@ class ilObjViMPAccess extends ilObjectPluginAccess {
 		return $ilAccess->checkAccess('rep_robj_xvmp_perm_upload', '', $ref_id);
 	}
 
+	/**
+	 * @param $ref_id
+	 *
+	 * @return bool
+	 */
+	public static function hasAccessToLink($ref_id = NULL) {
+		if ($ref_id === NULL) {
+			$ref_id = $_GET['ref_id'];
+		}
+		global $DIC;
+		$ilAccess = $DIC['ilAccess'];
+
+		/**
+		 * @var $ilAccess ilAccesshandler
+		 */
+
+		return $ilAccess->checkAccess('rep_robj_xvmp_perm_readlink', '', $ref_id);
+	}
+
 
 	/**
 	 * @param                 $action

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -109,6 +109,7 @@ flush_video_cache_tooltip#:#Die Videodaten werden in ILIAS zwischengespeichert, 
 repository_preview#:#Vorschau im Magazin
 no_preview#:#Keine Vorschau
 perm_upload#:#Upload
+perm_readlink#:#Link zum ViMP-Video
 access_denied#:#Zugriff verweigert.
 status_legal#:#Transkodierung abgeschlossen
 status_converting#:#Transkodierung läuft
@@ -171,6 +172,7 @@ root_create_xvmp#:#ViMP Erstellen
 xvmp_visible#:#Anzeigen: ViMP ist sichtbar
 xvmp_read#:#Lesezugriff: Videos können angezeigt werden
 xvmp_rep_robj_xvmp_perm_upload#:#Upload: Videos können hochgeladen werden
+rep_robj_xvmp_perm_readlink#:#Link zum Video kann angezeigt und kopiert werden
 xvmp_write#:#Einstellungen bearbeiten: Einstellungen und Inhalte können bearbeitet werden
 xvmp_delete#:#Löschen: Objekt kann gelöscht werden
 xvmp_edit_permission#:#Rechteeinstellungen ändern: Rechteeinstellungen ändern

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -109,6 +109,8 @@ flush_video_cache_tooltip#:#The video data is saved temporarily in ILIAS to allo
 repository_preview#:#Repository Preview
 no_preview#:#No Preview
 perm_upload#:#Upload
+perm_readlink#:#Link
+perm_readlink#:#Link to the Video at the ViMP Server
 access_denied#:#Permission denied.
 status_legal#:#Transcoded successfully
 status_converting#:#Transcoding
@@ -171,6 +173,7 @@ root_create_xvmp#:#Create ViMP
 xvmp_visible#:#Visible: ViMP is visible
 xvmp_read#:#Read: User can watch the videos
 xvmp_rep_robj_xvmp_perm_upload#:#Upload: User can upload videos
+rep_robj_xvmp_perm_readlink#:#User can view and copy the link to the video
 xvmp_write#:#Edit Settings: User can edit content and settings of ViMP object
 xvmp_delete#:#Delete: User can delete ViMP object
 xvmp_edit_permission#:#Change Permissions: User can change permission settings

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -114,3 +114,16 @@ xvmpConf::set(xvmpConf::F_ALLOW_PUBLIC, 1);
 xvmpConf::set(xvmpConf::F_MEDIA_PERMISSIONS_PRESELECTED, 1);
 xvmpConf::set(xvmpConf::F_DEFAULT_PUBLICATION, 2);
 ?>
+<#10>
+<?php
+require_once("./Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php");
+$xvmp_type_id = ilDBUpdateNewObjectType::addNewType('xvmp', 'Plugin ViMP');
+
+//Adding a new Permission rep_robj_xvmp_readlink ("Read link")
+$offering_admin = ilDBUpdateNewObjectType::addCustomRBACOperation( //$a_id, $a_title, $a_class, $a_pos
+	'rep_robj_xvmp_perm_readlink', 'readlink', 'object', 2010);
+if($offering_admin)
+{
+	ilDBUpdateNewObjectType::addRBACOperation($xvmp_type_id, $offering_admin);
+}
+?>

--- a/templates/default/modal.css
+++ b/templates/default/modal.css
@@ -26,3 +26,16 @@ h4.modal-title {
 	-ms-text-overflow: ellipsis;
 	text-overflow:     ellipsis;
 }
+
+div.form-horizontal.video-url{
+	padding: 0 10px 10px 0;
+	width: 50%;
+}
+input#videoUrl {
+	background-color: white;
+	font-size: 90%;
+}
+
+.video-url div.ilPermalinkContainer.input-group{
+	margin-top: 5px !important;
+}

--- a/templates/default/tpl.copylink.html
+++ b/templates/default/tpl.copylink.html
@@ -1,0 +1,25 @@
+<div class="link-info">
+    <p>{INFO_COPYLINK}</p>
+</div>
+<div class="ilInfoScreenSec form-horizontal video-url">
+    <div class="ilPermalinkContainer input-group">
+        <input class="form-control" readonly="readonly" id="videoUrl" type="text" value="{COPYLINK}" onclick="return false;">
+        <span class="input-group-btn">
+            <div class="btn-group">
+                <button type="button" class="btn btn-default" id="copyVideoUrl">
+                    <span></span>
+                    <span class="sr-only">Copy to clipboard</span>
+                    <span class="glyphicon glyphicon-copy"></span>
+                </button>
+            </div>
+        </span>
+    </div>
+</div>
+<script>
+    $('#copyVideoUrl', document).on('click', function (e) { 
+        let copyText = $('#videoUrl', document).get(0); 
+        copyText.select(); 
+        copyText.setSelectionRange(0, 99999); 
+        document.execCommand('copy') 
+    });
+</script>


### PR DESCRIPTION
We have developed and integrated a feature which enables the plugin to generate a link to the video from the vimp server and we'd like to share it with the community. The generated link can be copied(when users have enough permissions) and be used outside of ILIAS. A simple use case would be for example when one wants to play the video in bigbluebutton! The moderator will only have to copy the link and play it straight in bigbluebutton.

Here is a screenshot of the link box:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/57417057/138250135-d7ea2ad9-72b7-48c4-bb97-b162ff50aadf.png)


